### PR TITLE
Fix correlation computations

### DIFF
--- a/Housing-Prices-Forecast.ipynb
+++ b/Housing-Prices-Forecast.ipynb
@@ -616,7 +616,7 @@
     }
    ],
    "source": [
-    "corr_matrix = housing.corr(method='spearman').abs().sort_values(by='SalePrice', ascending=False)\n",
+    "corr_matrix = housing.corr(method='spearman', numeric_only=True).abs().sort_values(by='SalePrice', ascending=False)\n",
     "cor_target = abs(corr_matrix[\"SalePrice\"])\n",
     "#Selecting highly correlated features\n",
     "num_var = cor_target[cor_target>0.4]\n",
@@ -659,7 +659,7 @@
     "housing_num = housing[num_var.index]\n",
     "# Transform the target variable to log scale\n",
     "housing_num['SalePrice'] = housing_num['SalePrice'].apply(np.log)\n",
-    "corrmat = housing_num.corr(method='spearman').abs()\n",
+    "corrmat = housing_num.corr(method='spearman', numeric_only=True).abs()\n",
     "f, ax = plt.subplots(figsize=(12, 9))\n",
     "sns.heatmap(corrmat, vmax=1, square=True, annot=True);"
    ]
@@ -692,10 +692,10 @@
    "source": [
     "# Create correlation matrix\n",
     "housing_num_feat = housing[relevant_features.index]\n",
-    "corr_matrix = housing_num_feat.corr(method='spearman').abs()\n",
+    "corr_matrix = housing_num_feat.corr(method='spearman', numeric_only=True).abs()\n",
     "\n",
     "# Select upper triangle of correlation matrix\n",
-    "upper = corr_matrix.where(np.triu(np.ones(corr_matrix.shape), k=1).astype(np.bool))\n",
+    "upper = corr_matrix.where(np.triu(np.ones(corr_matrix.shape), k=1).astype(bool))\n",
     "\n",
     "# Find features with correlation greater than 0.8\n",
     "to_drop = [column for column in upper.columns if any(upper[column] > 0.8)]\n",
@@ -763,7 +763,7 @@
     }
    ],
    "source": [
-    "corrmat = housing_num.corr(method='spearman').abs()\n",
+    "corrmat = housing_num.corr(method='spearman', numeric_only=True).abs()\n",
     "f, ax = plt.subplots(figsize=(12, 9))\n",
     "sns.heatmap(corrmat, vmax=1, square=True, annot=True);\n"
    ]
@@ -1826,7 +1826,7 @@
    ],
    "source": [
     "features['SalePrice'] = housing_num['SalePrice']\n",
-    "corrmat = features.corr(method='spearman').abs()\n",
+    "corrmat = features.corr(method='spearman', numeric_only=True).abs()\n",
     "f, ax = plt.subplots(figsize=(12, 9))\n",
     "sns.heatmap(corrmat, vmax=1, square=True, annot=True);"
    ]
@@ -2762,7 +2762,7 @@
     "one_hot_encoder = OneHotEncoder()\n",
     "housing_cat_one = housing_cat[columns_one]\n",
     "housing_cat_encoded_one = one_hot_encoder.fit_transform(housing_cat_one)\n",
-    "housing_cat_encoded_one = pd.DataFrame(housing_cat_encoded_one.toarray(), columns=one_hot_encoder.get_feature_names(columns_one))\n",
+    "housing_cat_encoded_one = pd.DataFrame(housing_cat_encoded_one.toarray(), columns=one_hot_encoder.get_feature_names_out(columns_one))\n",
     "# concat the encoded columns with the original dataframe\n",
     "housing_cat.drop(columns_one, axis=1, inplace=True)\n",
     "housing_cat_encoded=pd.concat([housing_cat, housing_cat_encoded_one], axis=1)\n"


### PR DESCRIPTION
## Summary
- correct correlation functions to handle mixed data types
- replace deprecated `np.bool` usage
- use `get_feature_names_out` for OneHotEncoder

## Testing
- `python -m json.tool Housing-Prices-Forecast.ipynb`

------
https://chatgpt.com/codex/tasks/task_e_68400289a7cc832db0da0d1516ef4bee